### PR TITLE
Generate DisplayTimezone for DateTime elements with required attributes

### DIFF
--- a/src/Kontent.Ai.ModelGenerator.Core/Common/DisplayTimezoneProperty.cs
+++ b/src/Kontent.Ai.ModelGenerator.Core/Common/DisplayTimezoneProperty.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Kontent.Ai.ModelGenerator.Core.Helpers;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Kontent.Ai.ModelGenerator.Core.Common;
+
+public class DisplayTimezoneProperty : Property
+{
+    public string DateTimeElementCodename { get; init; }
+
+    public DisplayTimezoneProperty(string propertyCodename, string dateTimeElementCodename, string typeName, string id = null) : base(propertyCodename, typeName, id)
+    {
+        DateTimeElementCodename = dateTimeElementCodename;
+    }
+
+    public static new DisplayTimezoneProperty FromContentTypeElement(string elementCodename, string elementType)
+    {
+        if (elementType == "date_time")
+        {
+            var propertyCodename = elementCodename + "_display_timezone";
+            return new DisplayTimezoneProperty(propertyCodename, elementCodename, "string");
+        }
+
+        throw new ArgumentException($"Cannot create DisplayTimezone property from {elementType} type", nameof(elementType));
+    }
+}

--- a/src/Kontent.Ai.ModelGenerator.Core/DeliveryCodeGenerator.cs
+++ b/src/Kontent.Ai.ModelGenerator.Core/DeliveryCodeGenerator.cs
@@ -69,6 +69,16 @@ public class DeliveryCodeGenerator : CodeGeneratorBase
         return codeGenerators;
     }
 
+    protected static new void AddProperty(Property property, ref ClassDefinition classDefinition)
+    {
+        if (property is not DisplayTimezoneProperty)
+        {
+            classDefinition.AddPropertyCodenameConstant(property.Codename);
+        }
+
+        classDefinition.AddProperty(property);
+    }
+
     internal ClassCodeGenerator GetClassCodeGenerator(IContentType contentType)
     {
         var classDefinition = new ClassDefinition(contentType.System.Codename);
@@ -80,6 +90,12 @@ public class DeliveryCodeGenerator : CodeGeneratorBase
                 var elementType = DeliveryElementHelper.GetElementType(Options, element.Type);
                 var property = Property.FromContentTypeElement(element.Codename, elementType);
                 AddProperty(property, ref classDefinition);
+
+                if (elementType == "date_time")
+                {
+                    var displayTimezoneProperty = DisplayTimezoneProperty.FromContentTypeElement(element.Codename, elementType);
+                    AddProperty(displayTimezoneProperty, ref classDefinition);
+                }
             }
             catch (Exception e)
             {

--- a/src/Kontent.Ai.ModelGenerator.Core/Generators/Class/DeliveryClassCodeGeneratorBase.cs
+++ b/src/Kontent.Ai.ModelGenerator.Core/Generators/Class/DeliveryClassCodeGeneratorBase.cs
@@ -16,6 +16,7 @@ public abstract class DeliveryClassCodeGeneratorBase : ClassCodeGenerator
     protected MemberDeclarationSyntax[] Properties
         => ClassDefinition.Properties.OrderBy(p => p.Identifier).Select(element => SyntaxFactory
             .PropertyDeclaration(SyntaxFactory.ParseTypeName(element.TypeName), element.Identifier)
+            .EnsureAttributesForDisplayTimezones(element)
             .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
             .AddAccessorListAccessors(
                 GetAccessorDeclaration(SyntaxKind.GetAccessorDeclaration),


### PR DESCRIPTION
### Motivation - sanity check review

Implementing DateTimeElement DisplayTimezone support for DAPI model generation alongside [support in SDK PR](https://github.com/kontent-ai/delivery-sdk-net/pull/353)

Inspiration taken from PropertyValueConverters in SDK tests. Implemented converter that maps TZ value from DateTime into a property in model that is decorated with target element codename and the converter attribute. The PR cannot currently be merged/built and requires referencing locally built updated version of the SDK. If we decide to go with this approach, a new version of SDK nuget package has to be referenced. 

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

- Build updated version of SDK and add reference to `Kontent.Ai.Delivery.Abstractions` dll
- Try generating models from a project that contains content type with DateTime element and verify it contains <elementCodename>DisplayTimezone property with correct attributes (`DisplayTimzoneConverterAttribute` and `JsonPropertyAttribute("<elementCodename>")`)
- Try using these new models with new SDK version and verify that it consumes items correctly
- Try using updated SDK version with old models and verify this change is backwards-compatible
