### PR TITLE
disable test parallelization

### DIFF
--- a/test/Kontent.Ai.ModelGenerator.Tests/Properties/AssemblyInfo.cs
+++ b/test/Kontent.Ai.ModelGenerator.Tests/Properties/AssemblyInfo.cs
@@ -16,3 +16,9 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("9d6a9e5b-eb41-472a-90b2-df7e5eb43397")]
+
+// TODO: Come up with something better...
+// Hacky solution because StringWriter used by UserMessageLoggerTests
+// gets polluted from ArgHelpersTests, wherein Console.Error.WriteLine() is used.
+// Running the tests sequentially is slower but prevents pollution of Console.Error.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/Kontent.Ai.ModelGenerator.Tests/UserMessageLoggerTests.cs
+++ b/test/Kontent.Ai.ModelGenerator.Tests/UserMessageLoggerTests.cs
@@ -67,19 +67,18 @@ public class UserMessageLoggerTests
         _stringWriter.Flush();
     }
 
-    // TODO: Fix this test
-    // [Fact]
-    // public async Task LogErrorAsync_MessageIsLoggedToConsole()
-    // {
-    //     var message = "message";
-    //     var expectedMessage = $"{message}{Environment.NewLine}";
+    [Fact]
+    public async Task LogErrorAsync_MessageIsLoggedToConsole()
+    {
+        var message = "message";
+        var expectedMessage = $"{message}{Environment.NewLine}";
 
-    //     await _userMessageLogger.LogErrorAsync(message);
+        await _userMessageLogger.LogErrorAsync(message);
 
-    //     _stringWriter.ToString().Should().Be(expectedMessage);
+        _stringWriter.ToString().Should().Be(expectedMessage);
 
-    //     await _stringWriter.FlushAsync();
-    // }
+        await _stringWriter.FlushAsync();
+    }
 
     [Theory]
     [InlineData("")]


### PR DESCRIPTION
### Motivation

Disables test parallelization because tests fail intermittently due to static nature of `Console.Out`, which sometimes gets polluted by strings from simultaneously ran tests, thus failing other tests.

XUnit doesn't seem to have a [TextFixtureSetup] equivalent, so disabling parallelization is a cost-effective, albeit hacky solution that doesn't involve rewriting the tests completely or making ArgHelpers class non-static.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
